### PR TITLE
feat(starship): config

### DIFF
--- a/modules/starship.nix
+++ b/modules/starship.nix
@@ -18,5 +18,151 @@
     {
       programs.starship.enable = config.my.programs.starship.enable;
       programs.starship.enableNushellIntegration = config.my.programs.starship.enableNushellIntegration;
+
+      programs.starship.settings = {
+        add_newline = false;
+        format = lib.concatStrings [
+          "[](fg:red)"
+          "$os"
+          "$username"
+          "$hostname"
+          "[](fg:red)"
+          "[─](fg:overlay1)"
+          "[](fg:peach)"
+          "$directory"
+          "[](fg:peach)"
+          "[─](fg:overlay1)"
+          "[](fg:yellow)"
+          "$git_branch"
+          "$git_status"
+          "[](fg:yellow)"
+          "[─](fg:overlay1)"
+          "[](fg:green)"
+          "$direnv"
+          "$rust"
+          "$python"
+          "$deno"
+          "[](fg:green)"
+          "[─](fg:overlay1)"
+          "[](fg:lavender)"
+          "$time"
+          "[ ](fg:lavender)"
+          "$cmd_duration"
+          "$line_break"
+          "$character"
+        ];
+
+        os = {
+          disabled = false;
+          style = "bg:red fg:crust";
+          symbols = {
+            Windows = " ";
+            Ubuntu = "󰕈 ";
+            SUSE = " ";
+            Raspbian = "󰐿 ";
+            Mint = "󰣭 ";
+            Macos = "󰀵 ";
+            Manjaro = " ";
+            Linux = "󰌽 ";
+            Gentoo = "󰣨 ";
+            Fedora = "󰣛 ";
+            Alpine = " ";
+            Amazon = " ";
+            Android = " ";
+            Arch = "󰣇 ";
+            Artix = "󰣇 ";
+            CentOS = " ";
+            Debian = "󰣚 ";
+            Redhat = "󱄛 ";
+            RedHatEnterprise = "󱄛 ";
+            Pop = " ";
+            NixOS = " ";
+          };
+        };
+
+        username = {
+          show_always = true;
+          style_user = "bg:red fg:crust";
+          style_root = "bg:red fg:crust";
+          format = "[ $user]($style)";
+        };
+
+        hostname = {
+          disabled = false;
+          ssh_only = false;
+          style = "bg:red fg:crust";
+          format = "[@$hostname]($style)";
+        };
+
+        directory = {
+          style = "bg:peach fg:crust";
+          format = "[ $path ]($style)";
+          truncation_length = 3;
+          truncation_symbol = "…/";
+        };
+
+        git_branch = {
+          symbol = "";
+          style = "bg:yellow";
+          format = "[[ $symbol $branch ](fg:crust bg:yellow)]($style)";
+        };
+
+        git_status = {
+          style = "bg:yellow";
+          format = "[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)";
+        };
+
+        direnv = {
+          disabled = false;
+          style = "fg:crust bg:green";
+          format = "[$symbol$loaded/$allowed]($style)";
+        };
+
+        rust = {
+          symbol = "";
+          style = "bg:green";
+          format = "[[ $symbol( $version) ](fg:crust bg:green)]($style)";
+        };
+
+        python = {
+          symbol = "";
+          style = "bg:green";
+          format = "[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)";
+          detect_extensions = [ ];
+        };
+
+        deno = {
+          symbol = "";
+          style = "bg:green";
+          format = "[[ $symbol( $version) ](fg:crust bg:green)]($style)";
+        };
+
+        time = {
+          disabled = false;
+          time_format = "%R";
+          style = "bg:lavender";
+          format = "[[  $time ](fg:crust bg:lavender)]($style)";
+        };
+
+        character = {
+          disabled = false;
+          success_symbol = "[❯](bold fg:green)";
+          error_symbol = "[❯](bold fg:red)";
+          vimcmd_symbol = "[❮](bold fg:green)";
+          vimcmd_replace_one_symbol = "[❮](bold fg:lavender)";
+          vimcmd_replace_symbol = "[❮](bold fg:lavender)";
+          vimcmd_visual_symbol = "[❮](bold fg:yellow)";
+        };
+
+        cmd_duration = {
+          show_milliseconds = true;
+          format = " in $duration ";
+          style = "bg:lavender";
+          disabled = false;
+          show_notifications = false;
+          min_time = 0;
+        };
+      };
+
     };
 }


### PR DESCRIPTION
> Drafted by Pi with GPT-5.6-Luna

## Context

Track YAWSF issue mitigated by commit [`bc11f9a`](https://github.com/bitbloxhub/yawsf/commit/bc11f9a3ab11e164f48cd90336dab4e093e9cc64).

## Problem

A streaming request survives normal WebView teardown. Each open/close cycle can leave another connection behind. After suspend/resume, leaked streams eventually stop being read and create downstream backpressure. TCP sockets become `rwnd_limited`, data delivery stalls, and shell UI responsiveness degrades into severe lag.

Observed symptoms:

- Closing a WebView does not reliably close its streaming connection.
- Reopening the surface adds another active streaming connection.
- Leaked streams continue carrying data while their surface is closed.
- After prolonged sleep or suspend/resume, accumulated streams contribute to backpressure and lag.
- New sockets are initially healthy; degradation appears after stale streams accumulate and/or resume from sleep.

## Reproduction

1. Start YAWSF before commit `bc11f9a`.
2. Open a YAWSF WebView that makes a streaming request.
3. Confirm its connection to the YAWSF web API.
4. Close the layer-shell WebView.
5. Repeat open/close several times.
6. Inspect connections with `ss -tinp` and compare exact local/remote tuples.
7. Suspend/resume after stale streams accumulate.

Expected result: closing the WebView cancels its streaming request and the associated socket disappears promptly.

Actual result: the stream remains active or enters `CLOSE-WAIT` for an extended period. Repeated cycles accumulate stale connections and can cause lag after suspend/resume.

## Isolation results

The behavior reproduces in Epiphany when opening the same local streaming WebView page directly, then navigating to `about:blank`. This indicates the issue is not solely YAWSF's GTK window teardown path.

Observed WebKit behavior:

- Completed navigation to `about:blank` does not reliably cancel the streaming request.
- Detaching and destroying the WebView does not immediately finalize the WebView or window.
- Calling `terminate_web_process()` causes the stream to shut down.
- The socket first transitions from `ESTABLISHED` to `CLOSE-WAIT`; the WebKitNetworkProcess FD may remain for tens of seconds before disappearing.

## Current YAWSF workaround

Each embedded WebView receives its own `WebContext`. Teardown hides the window, calls `try_close()`, waits for the WebView `close` signal, calls `terminate_web_process()`, then destroys the window.

This prevents one surface's forced WebContent termination from affecting another surface. It also prevents stale streaming connections from accumulating across repeated lifecycle cycles, mitigating the severe UI lag observed after suspend/resume. It is a workaround, not a confirmed permanent fix.

## Follow-up

- Keep monitoring exact socket tuples and WebKitNetworkProcess FDs across suspend/resume.
- Verify whether sockets eventually disappear after forced WebContent termination.
- Track upstream WebKitGTK Fetch/NetworkProcess cleanup behavior.
- Remove the workaround only after normal document/WebView teardown reliably cancels streaming requests.
